### PR TITLE
chore: 统一 sed 查找替换

### DIFF
--- a/resource/deploy/20220723/install_online.sh
+++ b/resource/deploy/20220723/install_online.sh
@@ -3,7 +3,8 @@
 # 说明 --username --password 为必填值
 ###############  --path  可设置参数 ############################################
 datarc_verion=20220723
-datarc_dir=
+# datarc_dir 用于设置程序的安装目录。取消注释后正确设置。
+# datarc_dir=
 function main() {
   ARGS=$(getArgs "$@")
   path=$(echo "$ARGS" | getNamedArg path) ; [ ! $path ] && path='/opt/datarc'
@@ -220,7 +221,8 @@ EOF
 
   cd ${path} && wget -O datarc.sh https://r.datarc.cn/deploy/${datarc_verion}/install_online.sh
 
-  sed -i "6s%datarc_dir=%datarc_dir=${path}%" ${path}/datarc.sh
+  sed -i "s%# datarc_dir=%datarc_dir=${path}%" ${path}/datarc.sh
+
   (chmod +x ${path}/datarc.sh && cp ${path}/datarc.sh /usr/bin/datarc)
   datarc start
   echo_info "------ MinIO 账号：${minio_user} 密码：${minio_password} "

--- a/resource/deploy/20220723/install_online.sh
+++ b/resource/deploy/20220723/install_online.sh
@@ -220,9 +220,7 @@ services:
 EOF
 
   cd ${path} && wget -O datarc.sh https://r.datarc.cn/deploy/${datarc_verion}/install_online.sh
-
   sed -i "s%# datarc_dir=%datarc_dir=${path}%" ${path}/datarc.sh
-
   (chmod +x ${path}/datarc.sh && cp ${path}/datarc.sh /usr/bin/datarc)
   datarc start
   echo_info "------ MinIO 账号：${minio_user} 密码：${minio_password} "

--- a/resource/deploy/20220723/install_online.sh
+++ b/resource/deploy/20220723/install_online.sh
@@ -220,7 +220,7 @@ EOF
 
   cd ${path} && wget -O datarc.sh https://r.datarc.cn/deploy/${datarc_verion}/install_online.sh
 
-  sed -i "5s%datarc_dir=%datarc_dir=${path}%" ${path}/datarc.sh
+  sed -i "6s%datarc_dir=%datarc_dir=${path}%" ${path}/datarc.sh
   (chmod +x ${path}/datarc.sh && cp ${path}/datarc.sh /usr/bin/datarc)
   datarc start
   echo_info "------ MinIO 账号：${minio_user} 密码：${minio_password} "


### PR DESCRIPTION
加了 第 3 行备注，导致原先在 第 5 行的位置 变成了 第六行，导致 sed 替换第 5 行失败，更改为 替换 第 6 行